### PR TITLE
Fixed a bug on router/path

### DIFF
--- a/core/router/path.go
+++ b/core/router/path.go
@@ -209,12 +209,13 @@ func (ps *RoutePathReverser) Path(routeName string, paramValues ...interface{}) 
 	return r.ResolvePath(toStringSlice(paramValues)...)
 }
 
-func toStringSlice(args []interface{}) []string {
-	var argsString []string
-	if len(args) > 0 {
-		argsString = make([]string, len(args), len(args))
+func toStringSlice(args []interface{}) (argsString []string) {
+	argsSize := len(args)
+	if argsSize <= 0 {
+		return
 	}
 
+	argsString = make([]string, argsSize, argsSize)
 	for i, v := range args {
 		if s, ok := v.(string); ok {
 			argsString[i] = s
@@ -229,7 +230,7 @@ func toStringSlice(args []interface{}) []string {
 			}
 		}
 	}
-	return argsString
+	return
 }
 
 // Remove the URL for now, it complicates things for the whole framework without a specific benefits,
@@ -246,21 +247,16 @@ func (ps *RoutePathReverser) URL(routeName string, paramValues ...interface{}) (
 		return
 	}
 
-	if len(paramValues) == 0 {
-		return r.Path
-	}
-
-	args := toStringSlice(paramValues)
-
 	host := ps.vhost
 	scheme := ps.vscheme
+	args := toStringSlice(paramValues)
+
 	// if it's dynamic subdomain then the first argument is the subdomain part
 	// for this part we are responsible not the custom routers
-	if r.Subdomain == SubdomainWildcardIndicator {
+	if len(args) > 0 && r.Subdomain == SubdomainWildcardIndicator {
 		subdomain := args[0]
 		host = subdomain + "." + host
 		args = args[1:] // remove the subdomain part for the arguments,
-
 	}
 
 	if parsedPath := r.ResolvePath(args...); parsedPath != "" {


### PR DESCRIPTION
- Stored the args length on a variable instead of three consecutive calls to the len method on "toStringSlice" function;
- Improved readability on "toStringSlice" function;
- Fixed a bug on "URL", which all routes without parameters would not return the full uri (just the path);
- Fix issue: https://github.com/kataras/iris/issues/827